### PR TITLE
fix 2 label profiling issue

### DIFF
--- a/train.py
+++ b/train.py
@@ -46,6 +46,10 @@ print('')
 
 # here comes the magic, provide a JAX version of the `proba` function
 def minimal_predict_proba(X):
+    # create extra dimension when using 2 class labels to fix downstream tflite profiling/model testing
+    if clf.coef_.shape[0] == 1:
+        clf.coef_ = jnp.vstack([clf.coef_ * -1,clf.coef_])
+        clf.intercept_ = jnp.hstack([clf.intercept_ * -1, clf.intercept_])
     # first the linear model
     # see: https://github.com/scikit-learn/scikit-learn/blob/36958fb240fbe435673a9e3c52e769f01f36bec0/sklearn/linear_model/_base.py#L430
     y = jnp.dot(X, clf.coef_.T) + clf.intercept_


### PR DESCRIPTION
There is an issue with this block if you only have 2 labels in your dataset.
See this project: https://studio.edgeimpulse.com/studio/228301/

Current version shows correct validation accuracy in logs but then profiling gives wrong metrics due to sklearn only outputting one set of coeeficients and bias for a binary classification problem. We need 2 for downstream tflite model to function properly.

Current:
<img width="1266" alt="Screenshot 2023-05-19 at 10 15 48" src="https://github.com/edgeimpulse/example-custom-ml-block-scikit/assets/29129699/2d9715f2-4d58-4712-8807-e4b3fa963cb1">

After fix:
<img width="1292" alt="Screenshot 2023-05-19 at 10 16 50" src="https://github.com/edgeimpulse/example-custom-ml-block-scikit/assets/29129699/34b51453-7e24-4319-bdca-9f9a9659d323">

